### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/AbstractCenteredSilhouette.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/AbstractCenteredSilhouette.java
@@ -61,11 +61,6 @@ public abstract class AbstractCenteredSilhouette extends AbstractSilhouette impl
     private DoubleProperty centerY;
 
     @Override
-    public double getCenterX() {
-        return centerXProperty().get();
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public DoubleProperty centerXProperty() {
         if (centerX == null) {
@@ -76,16 +71,6 @@ public abstract class AbstractCenteredSilhouette extends AbstractSilhouette impl
     }
 
     @Override
-    public void setCenterX(double value) {
-        centerXProperty().set(value);
-    }
-
-    @Override
-    public double getCenterY() {
-        return centerYProperty().get();
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public DoubleProperty centerYProperty() {
         if (centerY == null) {
@@ -93,10 +78,5 @@ public abstract class AbstractCenteredSilhouette extends AbstractSilhouette impl
             centerY.addListener(updateListener);
         }
         return centerY;
-    }
-
-    @Override
-    public void setCenterY(double value) {
-        centerYProperty().set(value);
     }
 }

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/AbstractSilhouette.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/AbstractSilhouette.java
@@ -113,11 +113,6 @@ public abstract class AbstractSilhouette implements Silhouette {
         }
     };
 
-    @Override
-    public Shape getShape() {
-        return shapeProperty().get();
-    }
-
     protected void setShape(Shape shape) {
         shapeProperty().set(shape);
     }
@@ -160,11 +155,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     protected abstract void calculateShape();
 
     @Override
-    public Paint getFill() {
-        return fillProperty().get();
-    }
-
-    @Override
     public ObjectProperty<Paint> fillProperty() {
         if (fill == null) {
             fill = new SimpleObjectProperty<>(this, "fill", Color.BLACK);
@@ -174,32 +164,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setFill(Paint fill) {
-        fillProperty().set(fill);
-    }
-
-    @Override
-    public boolean isSmooth() {
-        return smoothProperty().get();
-    }
-
-    @Override
     public BooleanProperty smoothProperty() {
         if (smooth == null) {
             smooth = new SimpleBooleanProperty(this, "smooth", true);
             smooth.addListener((v, o, n) -> forwardShapeProperty(s -> s.setSmooth(n)));
         }
         return smooth;
-    }
-
-    @Override
-    public void setSmooth(boolean smooth) {
-        smoothProperty().set(smooth);
-    }
-
-    @Override
-    public double getStrokeDashOffset() {
-        return strokeDashOffsetProperty().get();
     }
 
     @Override
@@ -218,16 +188,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setStrokeDashOffset(double strokeDashOffset) {
-        strokeDashOffsetProperty().set(strokeDashOffset);
-    }
-
-    @Override
-    public StrokeLineCap getStrokeLineCap() {
-        return strokeLineCapProperty().get();
-    }
-
-    @Override
     public ObjectProperty<StrokeLineCap> strokeLineCapProperty() {
         if (strokeLineCap == null) {
             strokeLineCap = new SimpleObjectProperty<>(this, "strokeLineCap", DEFAULT_STROKE_LINE_CAP);
@@ -237,32 +197,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setStrokeLineCap(StrokeLineCap strokeLineCap) {
-        strokeLineCapProperty().set(strokeLineCap);
-    }
-
-    @Override
-    public StrokeLineJoin getStrokeLineJoin() {
-        return strokeLineJoinProperty().get();
-    }
-
-    @Override
     public ObjectProperty<StrokeLineJoin> strokeLineJoinProperty() {
         if (strokeLineJoin == null) {
             strokeLineJoin = new SimpleObjectProperty<>(this, "strokeLineJoin", DEFAULT_STROKE_LINE_JOIN);
             strokeLineJoin.addListener((v, o, n) -> forwardShapeProperty(s -> setStrokeLineJoin(n)));
         }
         return strokeLineJoin;
-    }
-
-    @Override
-    public void setStrokeLineJoin(StrokeLineJoin strokeLineJoin) {
-        strokeLineJoinProperty().set(strokeLineJoin);
-    }
-
-    @Override
-    public double getStrokeMiterLimit() {
-        return strokeMiterLimitProperty().get();
     }
 
     @Override
@@ -281,16 +221,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setStrokeMiterLimit(double strokeMiterLimit) {
-        strokeMiterLimitProperty().set(strokeMiterLimit);
-    }
-
-    @Override
-    public Paint getStroke() {
-        return strokeProperty().get();
-    }
-
-    @Override
     public ObjectProperty<Paint> strokeProperty() {
         if (stroke == null) {
             stroke = new SimpleObjectProperty<>(this, "stroke", Color.BLACK);
@@ -300,32 +230,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setStroke(Paint stroke) {
-        strokeProperty().set(stroke);
-    }
-
-    @Override
-    public StrokeType getStrokeType() {
-        return strokeTypeProperty().get();
-    }
-
-    @Override
     public ObjectProperty<StrokeType> strokeTypeProperty() {
         if (strokeType == null) {
             strokeType = new SimpleObjectProperty<>(this, "strokeType", DEFAULT_STROKE_TYPE);
             strokeType.addListener((v, o, n) -> forwardShapeProperty(s -> s.setStrokeType(n)));
         }
         return strokeType;
-    }
-
-    @Override
-    public void setStrokeType(StrokeType strokeType) {
-        strokeTypeProperty().set(strokeType);
-    }
-
-    @Override
-    public double getStrokeWidth() {
-        return strokeWidthProperty().get();
     }
 
     @Override
@@ -344,16 +254,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setStrokeWidth(double strokeWidth) {
-        strokeWidthProperty().set(strokeWidth);
-    }
-
-    @Override
-    public String getId() {
-        return idProperty().get();
-    }
-
-    @Override
     public StringProperty idProperty() {
         if (id == null) {
             id = new SimpleStringProperty(this, "id");
@@ -363,32 +263,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setId(String id) {
-        idProperty().set(id);
-    }
-
-    @Override
-    public boolean isManaged() {
-        return managedProperty().get();
-    }
-
-    @Override
     public BooleanProperty managedProperty() {
         if (managed == null) {
             managed = new SimpleBooleanProperty(this, "managed", true);
             managed.addListener((v, o, n) -> forwardShapeProperty(s -> s.setManaged(n)));
         }
         return managed;
-    }
-
-    @Override
-    public void setManaged(boolean managed) {
-        managedProperty().set(managed);
-    }
-
-    @Override
-    public double getOpacity() {
-        return opacityProperty().get();
     }
 
     @Override
@@ -407,16 +287,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setOpacity(double opacity) {
-        opacityProperty().set(opacity);
-    }
-
-    @Override
-    public double getRotate() {
-        return rotateProperty().get();
-    }
-
-    @Override
     public DoubleProperty rotateProperty() {
         if (rotate == null) {
             rotate = new SimpleDoubleProperty(this, "rotate", 0);
@@ -432,32 +302,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setRotate(double rotate) {
-        rotateProperty().set(rotate);
-    }
-
-    @Override
-    public Point3D getRotationAxis() {
-        return rotationAxisProperty().get();
-    }
-
-    @Override
     public ObjectProperty<Point3D> rotationAxisProperty() {
         if (rotationAxis == null) {
             rotationAxis = new SimpleObjectProperty<>(this, "rotationAxis", Rotate.Z_AXIS);
             rotationAxis.addListener((v, o, n) -> forwardShapeProperty(s -> s.setRotationAxis(n)));
         }
         return rotationAxis;
-    }
-
-    @Override
-    public void setRotationAxis(Point3D rotationAxis) {
-        rotationAxisProperty().set(rotationAxis);
-    }
-
-    @Override
-    public double getScaleX() {
-        return scaleXProperty().get();
     }
 
     @Override
@@ -476,16 +326,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setScaleX(double scaleX) {
-        scaleXProperty().set(scaleX);
-    }
-
-    @Override
-    public double getScaleY() {
-        return scaleYProperty().get();
-    }
-
-    @Override
     public DoubleProperty scaleYProperty() {
         if (scaleY == null) {
             scaleY = new SimpleDoubleProperty(this, "scaleY", 1);
@@ -498,16 +338,6 @@ public abstract class AbstractSilhouette implements Silhouette {
             });
         }
         return scaleY;
-    }
-
-    @Override
-    public void setScaleY(double scaleY) {
-        scaleYProperty().set(scaleY);
-    }
-
-    @Override
-    public double getScaleZ() {
-        return scaleZProperty().get();
     }
 
     @Override
@@ -526,32 +356,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setScaleZ(double scaleZ) {
-        scaleZProperty().set(scaleZ);
-    }
-
-    @Override
-    public String getStyle() {
-        return styleProperty().get();
-    }
-
-    @Override
     public StringProperty styleProperty() {
         if (style == null) {
             style = new SimpleStringProperty(this, "id");
             style.addListener((v, o, n) -> forwardShapeProperty(s -> s.setStyle(n)));
         }
         return style;
-    }
-
-    @Override
-    public void setStyle(String style) {
-        styleProperty().set(style);
-    }
-
-    @Override
-    public double getTranslateX() {
-        return translateXProperty().get();
     }
 
     @Override
@@ -570,16 +380,6 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setTranslateX(double translateX) {
-        translateXProperty().set(translateX);
-    }
-
-    @Override
-    public double getTranslateY() {
-        return translateYProperty().get();
-    }
-
-    @Override
     public DoubleProperty translateYProperty() {
         if (translateY == null) {
             translateY = new SimpleDoubleProperty(this, "translateY", 0);
@@ -592,16 +392,6 @@ public abstract class AbstractSilhouette implements Silhouette {
             });
         }
         return translateY;
-    }
-
-    @Override
-    public void setTranslateY(double translateY) {
-        translateYProperty().set(translateY);
-    }
-
-    @Override
-    public double getTranslateZ() {
-        return translateZProperty().get();
     }
 
     @Override
@@ -620,27 +410,12 @@ public abstract class AbstractSilhouette implements Silhouette {
     }
 
     @Override
-    public void setTranslateZ(double translateZ) {
-        translateZProperty().set(translateZ);
-    }
-
-    @Override
-    public boolean isVisible() {
-        return visibleProperty().get();
-    }
-
-    @Override
     public BooleanProperty visibleProperty() {
         if (visible == null) {
             visible = new SimpleBooleanProperty(this, "managed", true);
             visible.addListener((v, o, n) -> forwardShapeProperty(s -> s.setVisible(n)));
         }
         return visible;
-    }
-
-    @Override
-    public void setVisible(boolean visible) {
-        visibleProperty().set(visible);
     }
 
     protected void forwardShapeProperty(Consumer<Shape> consumer) {

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/CenteredSilhouette.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/CenteredSilhouette.java
@@ -56,13 +56,21 @@ import javafx.beans.property.DoubleProperty;
  * @author Andres Almiray
  */
 public interface CenteredSilhouette extends Silhouette {
-    double getCenterX();
+    default double getCenterX() {
+        return centerXProperty().get();
+    }
 
-    double getCenterY();
+    default double getCenterY() {
+        return centerYProperty().get();
+    }
 
-    void setCenterX(double value);
+    default void setCenterX(double value) {
+        centerXProperty().set(value);
+    }
 
-    void setCenterY(double value);
+    default void setCenterY(double value) {
+        centerYProperty().set(value);
+    }
 
     DoubleProperty centerXProperty();
 

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Silhouette.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Silhouette.java
@@ -65,144 +65,234 @@ import javafx.scene.shape.StrokeType;
  * @author Andres Almiray
  */
 public interface Silhouette {
-    Shape getShape();
+    default Shape getShape() {
+        return shapeProperty().get();
+    }
 
     ObjectProperty<Shape> shapeProperty();
 
-    Paint getFill();
+    default Paint getFill() {
+        return fillProperty().get();
+    }
 
     ObjectProperty<Paint> fillProperty();
 
-    void setFill(Paint fill);
+    default void setFill(Paint fill) {
+        fillProperty().set(fill);
+    }
 
-    boolean isSmooth();
+    default boolean isSmooth() {
+        return smoothProperty().get();
+    }
 
     BooleanProperty smoothProperty();
 
-    void setSmooth(boolean smooth);
+    default void setSmooth(boolean smooth) {
+        smoothProperty().set(smooth);
+    }
 
-    double getStrokeDashOffset();
+    default double getStrokeDashOffset() {
+        return strokeDashOffsetProperty().get();
+    }
 
     DoubleProperty strokeDashOffsetProperty();
 
-    void setStrokeDashOffset(double strokeDashOffset);
+    default void setStrokeDashOffset(double strokeDashOffset) {
+        strokeDashOffsetProperty().set(strokeDashOffset);
+    }
 
-    StrokeLineCap getStrokeLineCap();
+    default StrokeLineCap getStrokeLineCap() {
+        return strokeLineCapProperty().get();
+    }
 
     ObjectProperty<StrokeLineCap> strokeLineCapProperty();
 
-    void setStrokeLineCap(StrokeLineCap strokeLineCap);
+    default void setStrokeLineCap(StrokeLineCap strokeLineCap) {
+        strokeLineCapProperty().set(strokeLineCap);
+    }
 
-    StrokeLineJoin getStrokeLineJoin();
+    default StrokeLineJoin getStrokeLineJoin() {
+        return strokeLineJoinProperty().get();
+    }
 
     ObjectProperty<StrokeLineJoin> strokeLineJoinProperty();
 
-    void setStrokeLineJoin(StrokeLineJoin strokeLineJoin);
+    default void setStrokeLineJoin(StrokeLineJoin strokeLineJoin) {
+        strokeLineJoinProperty().set(strokeLineJoin);
+    }
 
-    double getStrokeMiterLimit();
+    default double getStrokeMiterLimit() {
+        return strokeMiterLimitProperty().get();
+    }
 
     DoubleProperty strokeMiterLimitProperty();
 
-    void setStrokeMiterLimit(double strokeMiterLimit);
+    default void setStrokeMiterLimit(double strokeMiterLimit) {
+        strokeMiterLimitProperty().set(strokeMiterLimit);
+    }
 
-    Paint getStroke();
+    default Paint getStroke() {
+        return strokeProperty().get();
+    }
 
     ObjectProperty<Paint> strokeProperty();
 
-    void setStroke(Paint stroke);
+    default void setStroke(Paint stroke) {
+        strokeProperty().set(stroke);
+    }
 
-    StrokeType getStrokeType();
+    default StrokeType getStrokeType() {
+        return strokeTypeProperty().get();
+    }
 
     ObjectProperty<StrokeType> strokeTypeProperty();
 
-    void setStrokeType(StrokeType strokeType);
+    default void setStrokeType(StrokeType strokeType) {
+        strokeTypeProperty().set(strokeType);
+    }
 
-    double getStrokeWidth();
+    default double getStrokeWidth() {
+        return strokeWidthProperty().get();
+    }
 
     DoubleProperty strokeWidthProperty();
 
-    void setStrokeWidth(double strokeWidth);
+    default void setStrokeWidth(double strokeWidth) {
+        strokeWidthProperty().set(strokeWidth);
+    }
 
     static double normalizeAngle(double angle) {
         angle = angle % 360;
         return angle < 0 ? angle + 360 : angle;
     }
 
-    String getId();
+    default String getId() {
+        return idProperty().get();
+    }
 
     StringProperty idProperty();
 
-    void setId(String id);
+    default void setId(String id) {
+        idProperty().set(id);
+    }
 
-    boolean isManaged();
+    default boolean isManaged() {
+        return managedProperty().get();
+    }
 
     BooleanProperty managedProperty();
 
-    void setManaged(boolean managed);
+    default void setManaged(boolean managed) {
+        managedProperty().set(managed);
+    }
 
-    double getOpacity();
+    default double getOpacity() {
+        return opacityProperty().get();
+    }
 
     DoubleProperty opacityProperty();
 
-    void setOpacity(double opacity);
+    default void setOpacity(double opacity) {
+        opacityProperty().set(opacity);
+    }
 
-    double getRotate();
+    default double getRotate() {
+        return rotateProperty().get();
+    }
 
     DoubleProperty rotateProperty();
 
-    void setRotate(double rotate);
+    default void setRotate(double rotate) {
+        rotateProperty().set(rotate);
+    }
 
-    Point3D getRotationAxis();
+    default Point3D getRotationAxis() {
+        return rotationAxisProperty().get();
+    }
 
     ObjectProperty<Point3D> rotationAxisProperty();
 
-    void setRotationAxis(Point3D rotationAxis);
+    default void setRotationAxis(Point3D rotationAxis) {
+        rotationAxisProperty().set(rotationAxis);
+    }
 
-    double getScaleX();
+    default double getScaleX() {
+        return scaleXProperty().get();
+    }
 
     DoubleProperty scaleXProperty();
 
-    void setScaleX(double scaleX);
+    default void setScaleX(double scaleX) {
+        scaleXProperty().set(scaleX);
+    }
 
-    double getScaleY();
+    default double getScaleY() {
+        return scaleYProperty().get();
+    }
 
     DoubleProperty scaleYProperty();
 
-    void setScaleY(double scaleY);
+    default void setScaleY(double scaleY) {
+        scaleYProperty().set(scaleY);
+    }
 
-    double getScaleZ();
+    default double getScaleZ() {
+        return scaleZProperty().get();
+    }
 
     DoubleProperty scaleZProperty();
 
-    void setScaleZ(double scaleZ);
+    default void setScaleZ(double scaleZ) {
+        scaleZProperty().set(scaleZ);
+    }
 
-    String getStyle();
+    default String getStyle() {
+        return styleProperty().get();
+    }
 
     StringProperty styleProperty();
 
-    void setStyle(String style);
+    default void setStyle(String style) {
+        styleProperty().set(style);
+    }
 
-    double getTranslateX();
+    default double getTranslateX() {
+        return translateXProperty().get();
+    }
 
     DoubleProperty translateXProperty();
 
-    void setTranslateX(double translateX);
+    default void setTranslateX(double translateX) {
+        translateXProperty().set(translateX);
+    }
 
-    double getTranslateY();
+    default double getTranslateY() {
+        return translateYProperty().get();
+    }
 
     DoubleProperty translateYProperty();
 
-    void setTranslateY(double translateY);
+    default void setTranslateY(double translateY) {
+        translateYProperty().set(translateY);
+    }
 
-    double getTranslateZ();
+    default double getTranslateZ() {
+        return translateZProperty().get();
+    }
 
     DoubleProperty translateZProperty();
 
-    void setTranslateZ(double translateZ);
+    default void setTranslateZ(double translateZ) {
+        translateZProperty().set(translateZ);
+    }
 
-    boolean isVisible();
+    default boolean isVisible() {
+        return visibleProperty().get();
+    }
 
     BooleanProperty visibleProperty();
 
-    void setVisible(boolean visible);
+    default void setVisible(boolean visible) {
+        visibleProperty().set(visible);
+    }
 }


### PR DESCRIPTION
This is a semantics-preserving refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as default methods. The tool **does not** add new code; it only rearranges *existing* code.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes with the hopes of such methods being suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.
- We have run tests prior to applying to the tool and following the application. All tests pass.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if each of the proposed changes are helpful or not.