### PR TITLE
Rejuvenate log levels

### DIFF
--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Arrow.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Arrow.java
@@ -199,7 +199,7 @@ public class Arrow extends AbstractSilhouette {
 
     private double validateDepth(double depth) {
         if (depth < 0 || depth > 1) {
-            LOG.info(() -> "depth (" + depth + ") must be inside the range [0..1]");
+            LOG.finest(() -> "depth (" + depth + ") must be inside the range [0..1]");
             return 0.5;
         }
         return depth;
@@ -207,7 +207,7 @@ public class Arrow extends AbstractSilhouette {
 
     private double validateRise(double rise) {
         if (rise < 0 || rise > 1) {
-            LOG.info(() -> "rise (" + rise + ") must be inside the range [0..1]");
+            LOG.finest(() -> "rise (" + rise + ") must be inside the range [0..1]");
             return 0.5;
         }
         return rise;

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Asterisk.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Asterisk.java
@@ -177,7 +177,7 @@ public class Asterisk extends AbstractCenteredSilhouette {
 
     private int validateBeamCount(int beamCount) {
         if (beamCount < 2) {
-            LOG.info(() -> "beamCount (" + beamCount + ") can not be less than 2");
+            LOG.finest(() -> "beamCount (" + beamCount + ") can not be less than 2");
             return 2;
         }
         return beamCount;
@@ -185,10 +185,10 @@ public class Asterisk extends AbstractCenteredSilhouette {
 
     private double validateRoundness(double roundness) {
         if (roundness < 0) {
-            LOG.info(() -> "roundness (" + roundness + ") must be inside the range [0..1]");
+            LOG.finest(() -> "roundness (" + roundness + ") must be inside the range [0..1]");
             return 0;
         } else if (roundness > 1) {
-            LOG.info(() -> "roundness (" + roundness + " ) must be inside the range [0..1]");
+            LOG.finest(() -> "roundness (" + roundness + " ) must be inside the range [0..1]");
             return 1;
         }
         return roundness;
@@ -196,7 +196,7 @@ public class Asterisk extends AbstractCenteredSilhouette {
 
     private double validateWidth(double width, double radius) {
         if (width > radius * 2) {
-            LOG.info(() -> "width (" + width + ") can not be greater than radius * 2 (" + (radius * 2) + ")");
+            LOG.finest(() -> "width (" + width + ") can not be greater than radius * 2 (" + (radius * 2) + ")");
             return radius * 2;
         }
         return width;

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Cross.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Cross.java
@@ -143,10 +143,10 @@ public class Cross extends AbstractCenteredSilhouette {
 
     protected double validateRoundness(double roundness) {
         if (roundness < 0) {
-            LOG.info(() -> "roundness (" + roundness + ") must be inside the range [0..1]");
+            LOG.finest(() -> "roundness (" + roundness + ") must be inside the range [0..1]");
             return 0;
         } else if (roundness > 1) {
-            LOG.info(() -> "roundness (" + roundness + " ) must be inside the range [0..1]");
+            LOG.finest(() -> "roundness (" + roundness + " ) must be inside the range [0..1]");
             return 1;
         }
         return roundness;
@@ -154,7 +154,7 @@ public class Cross extends AbstractCenteredSilhouette {
 
     protected double validateWidth(double width, double radius) {
         if (width > radius * 2) {
-            LOG.info(() -> "width (" + width + ") can not be greater than radius * 2 (" + (radius * 2) + ")");
+            LOG.finest(() -> "width (" + width + ") can not be greater than radius * 2 (" + (radius * 2) + ")");
             return radius * 2;
         }
         return width;

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Donut.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Donut.java
@@ -132,12 +132,12 @@ public class Donut extends AbstractCenteredSilhouette {
         int s = getSides();
 
         if (ir >= or) {
-            LOG.info("'ir' can not be equal greater than 'or' [ir=" + ir + ", or=" + or + "]");
+            LOG.finest("'ir' can not be equal greater than 'or' [ir=" + ir + ", or=" + or + "]");
             ir = 3;
             or = 8;
         }
         if (ir < 0 || or < 0) {
-            LOG.info("radii can not be less than zero [ir=" + ir + ", or=" + or + "]");
+            LOG.finest("radii can not be less than zero [ir=" + ir + ", or=" + or + "]");
             ir = 3;
             or = 8;
         }

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/MultiRoundRectangle.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/MultiRoundRectangle.java
@@ -313,22 +313,22 @@ public class MultiRoundRectangle extends AbstractSilhouette {
         double brh = getBottomRightHeight();
 
         if (blw + brw > w) {
-            LOG.info("bottom rounding factors are invalid: " + blw + " + " + brw + " > " + w);
+            LOG.finest("bottom rounding factors are invalid: " + blw + " + " + brw + " > " + w);
             blw = brw = 0;
         }
 
         if (tlh + blh > h) {
-            LOG.info("left rounding factors are invalid: " + tlh + " + " + blh + " > " + h);
+            LOG.finest("left rounding factors are invalid: " + tlh + " + " + blh + " > " + h);
             tlh = blh = 0;
         }
 
         if (trh + brh > h) {
-            LOG.info("right rounding factors are invalid: " + trh + " + " + brh + " > " + h);
+            LOG.finest("right rounding factors are invalid: " + trh + " + " + brh + " > " + h);
             trh = brh = 0;
         }
 
         if (tlw + trw > w) {
-            LOG.info("top rounding factors are invalid: " + tlw + " + " + trw + " > " + w);
+            LOG.finest("top rounding factors are invalid: " + tlw + " + " + trw + " > " + w);
             tlw = trw = 0;
         }
 

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Rays.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Rays.java
@@ -205,7 +205,7 @@ public class Rays extends AbstractCenteredSilhouette {
 
     private int validateBeamCount(int beamCount) {
         if (beamCount < 2) {
-            LOG.info(() -> "beamCount (" + beamCount + ") can not be less than 2");
+            LOG.finest(() -> "beamCount (" + beamCount + ") can not be less than 2");
             return 2;
         }
         return beamCount;
@@ -213,10 +213,10 @@ public class Rays extends AbstractCenteredSilhouette {
 
     protected double validateExtent(double extent) {
         if (extent < 0) {
-            LOG.info(() -> "extent (" + extent + ") must be inside the range [0..1]");
+            LOG.finest(() -> "extent (" + extent + ") must be inside the range [0..1]");
             return 0;
         } else if (extent > 1) {
-            LOG.info(() -> "extent (" + extent + " ) must be inside the range [0..1]");
+            LOG.finest(() -> "extent (" + extent + " ) must be inside the range [0..1]");
             return 1;
         }
         return extent;

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/RegularPolygon.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/RegularPolygon.java
@@ -142,7 +142,7 @@ public class RegularPolygon extends AbstractCenteredSilhouette {
 
     private int validateSides(int sides) {
         if (sides < 3) {
-            LOG.info(() -> "sides (" + sides + ") can not be less than 3");
+            LOG.finest(() -> "sides (" + sides + ") can not be less than 3");
             return 3;
         }
         return sides;

--- a/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Star.java
+++ b/subprojects/jsilhouette-javafx/src/main/java/org/kordamp/jsilhouette/javafx/Star.java
@@ -131,17 +131,17 @@ public class Star extends AbstractCenteredSilhouette {
         int s = getSides();
 
         if (s < 2) {
-            LOG.info("sides (" + s + ") can not be less than 2");
+            LOG.finest("sides (" + s + ") can not be less than 2");
             s = 2;
         }
 
         if (ir >= or) {
-            LOG.info("'ir' can not be equal greater than 'or' [ir=" + ir + ", or=" + or + "]");
+            LOG.finest("'ir' can not be equal greater than 'or' [ir=" + ir + ", or=" + or + "]");
             ir = 3;
             or = 8;
         }
         if (ir < 0 || or < 0) {
-            LOG.info("radii can not be less than zero [ir=" + ir + ", or=" + or + "]");
+            LOG.finest("radii can not be less than zero [ir=" + ir + ", or=" + or + "]");
             ir = 3;
             or = 8;
         }


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., `INFO` as compared to `FINEST`) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

## Feedback Request

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can comment on *each* of the transformations (if possible) in the case that this PR is not accepted. If there there are too many transformations to review, letting us know where you left off would be helpful. Of course, we would also love to contribute to your project if you wish.

## Settings

We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
1. Never lower the logging level of logging statements within catch blocks.
1. Never lower the logging level of logging statements containing certain (important) keywords.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 300.

The head at time of analysis was: 517fc2b873602991898691e1c1f074428e7a6604